### PR TITLE
Revert "Added Screen View event type."

### DIFF
--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -453,8 +453,7 @@ public class IterableExtension extends MessageProcessor {
                 Event.Type.PUSH_MESSAGE_RECEIPT,
                 Event.Type.PUSH_MESSAGE_OPEN,
                 Event.Type.USER_IDENTITY_CHANGE,
-                Event.Type.PRODUCT_ACTION,
-                Event.Type.SCREEN_VIEW);
+                Event.Type.PRODUCT_ACTION);
 
         eventProcessingRegistration.setSupportedEventTypes(supportedEventTypes);
         response.setEventProcessingRegistration(eventProcessingRegistration);
@@ -572,35 +571,6 @@ public class IterableExtension extends MessageProcessor {
         request.createdAt = (int) (event.getTimestamp() / 1000.0);
         request.dataFields = attemptTypeConversion(event.getAttributes());
         List<UserIdentity> identities = event.getRequest().getUserIdentities();
-        if (identities != null) {
-            for (UserIdentity identity : identities) {
-                if (identity.getType().equals(UserIdentity.Type.EMAIL)) {
-                    request.email = identity.getValue();
-                } else if (identity.getType().equals(UserIdentity.Type.CUSTOMER)) {
-                    request.userId = identity.getValue();
-                }
-            }
-        }
-
-        Response<IterableApiResponse> response = iterableService.track(getApiKey(event), request).execute();
-        if (response.isSuccessful() && !response.body().isSuccess()) {
-            throw new IOException(response.body().toString());
-        } else if (!response.isSuccessful()) {
-            throw new IOException("Error sending custom event to Iterable: HTTP " + response.code());
-        }
-    }
-
-    @Override
-    public void processScreenViewEvent(ScreenViewEvent event) throws IOException {
-        if (processSubscribeEvent(event)) {
-            return;
-        }
-
-        TrackRequest request = new TrackRequest("Screen View");
-        request.createdAt = (int) (event.getTimestamp() / 1000.0);
-        request.dataFields = attemptTypeConversion(event.getAttributes());
-        request.dataFields.put("screenName", event.getScreenName());
-        List<UserIdentity> identities = event.getContext().getUserIdentities();
         if (identities != null) {
             for (UserIdentity identity : identities) {
                 if (identity.getType().equals(UserIdentity.Type.EMAIL)) {


### PR DESCRIPTION
Reverts Iterable/mparticle-firehose-iterable#2

Merged pre-maturely, need to fix the following error:

```
:iterable-extension:compileJava
/Users/kevin.tham/dev/mparticle-firehose-iterable/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java:595: error: incompatible types: ScreenViewEvent cannot be converted to CustomEvent
        if (processSubscribeEvent(event)) {
                                  ^
/Users/kevin.tham/dev/mparticle-firehose-iterable/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java:603: error: cannot find symbol
        List<UserIdentity> identities = event.getContext().getUserIdentities();
                                             ^
  symbol:   method getContext()
  location: variable event of type ScreenViewEvent
Note: /Users/kevin.tham/dev/mparticle-firehose-iterable/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /Users/kevin.tham/dev/mparticle-firehose-iterable/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
2 errors
:iterable-extension:compileJava FAILED
```