### PR TITLE
Update allowed maximum data age to 30 days

### DIFF
--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -456,6 +456,7 @@ public class IterableExtension extends MessageProcessor {
                 Event.Type.PRODUCT_ACTION);
 
         eventProcessingRegistration.setSupportedEventTypes(supportedEventTypes);
+        eventProcessingRegistration.setMaxDataAgeHours(24*30);
         response.setEventProcessingRegistration(eventProcessingRegistration);
         AudienceProcessingRegistration audienceRegistration = new AudienceProcessingRegistration();
         audienceRegistration.setAccountSettings(audienceSettings);


### PR DESCRIPTION
Hello! I'm creating this PR mostly as an example. If you would like the integration to receive data that's older than 24 hours (perhaps, for data replays) - you'll have to update your `ModuleRegistrationResponse` as displayed here. I picked 30 days arbitrarily so feel free to edit as you wish.

If you do choose to make any change from 24 hours - mParticle can quickly re-import the integration to reflect.