### PR TITLE
Add the ability to parse user attribute types

### DIFF
--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -468,6 +468,11 @@ public class IterableExtension extends MessageProcessor {
                         .setIsRequired(false)
                         .setDescription("APNS Production integration name set up in the Mobile Push section of your Iterable account.")
         );
+        eventSettings.add(
+                new BooleanSetting(SETTING_COERCE_STRINGS_TO_SCALARS, "Coerce Strings to Scalars")
+                        .setIsChecked(true)
+                        .setDescription("If enabled, mParticle will attempt to coerce string attributes into scalar types (integer, boolean, and float).")
+        );
         eventProcessingRegistration.setAccountSettings(eventSettings);
 
         // Specify supported event types

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -411,7 +411,7 @@ public class IterableExtension extends MessageProcessor {
 
     @Override
     public ModuleRegistrationResponse processRegistrationRequest(ModuleRegistrationRequest request) {
-        ModuleRegistrationResponse response = new ModuleRegistrationResponse(NAME, "1.5.1");
+        ModuleRegistrationResponse response = new ModuleRegistrationResponse(NAME, "1.6.0");
 
         Permissions permissions = new Permissions();
         permissions.setUserIdentities(

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -247,7 +247,7 @@ public class IterableExtension extends MessageProcessor {
 
     private Map<String, Object> getUserAttributes(EventProcessingRequest request) {
         String settingValue = request.getAccount().getAccountSettings().get(SETTING_PARSE_USER_ATTRIBUTES);
-        Boolean parseUserAttributes = Boolean.parseBoolean(settingValue);
+        boolean parseUserAttributes = Boolean.parseBoolean(settingValue);
 
         Map<String, String> userAttributes = request.getUserAttributes();
         if (userAttributes == null) {

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -308,7 +308,7 @@ public class IterableExtension extends MessageProcessor {
 
     CommerceItem convertToCommerceItem(Product product, boolean shouldCoerceStrings) {
         CommerceItem item = new CommerceItem();
-        item.dataFields = convertAttributes(product.getAttributes(), shouldCoerceStrings); // change?
+        item.dataFields = convertAttributes(product.getAttributes(), shouldCoerceStrings);
         //iterable requires ID, and they also take SKU. mParticle doesn't differentiate
         //between sku and id. so, use our sku/id for both in Iterable:
         item.id = item.sku = product.getId();

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -247,9 +247,7 @@ public class IterableExtension extends MessageProcessor {
 
     private Map<String, Object> getUserAttributes(EventProcessingRequest request) {
         String settingValue = request.getAccount().getAccountSettings().get(SETTING_PARSE_USER_ATTRIBUTES);
-        Boolean parseUserAttributes = settingValue == null ?
-            false :
-            Boolean.parseBoolean(settingValue.toLowerCase(Locale.US));
+        Boolean parseUserAttributes = Boolean.parseBoolean(settingValue);
 
         Map<String, String> userAttributes = request.getUserAttributes();
         if (userAttributes == null) {

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -263,6 +263,9 @@ public class IterableExtension extends MessageProcessor {
     private static boolean shouldCoerceStrings(EventProcessingRequest request) {
         String settingValue = request.getAccount().getAccountSettings().get(SETTING_COERCE_STRINGS_TO_SCALARS);
         
+        if (settingValue == null) { 
+            return false;
+        }
         return Boolean.parseBoolean(settingValue);
     }
 

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -252,8 +252,7 @@ public class IterableExtension extends MessageProcessor {
         
         if (coerceStringsToScalars) {
             return attemptTypeConversion(attributes);
-        }
-        else {
+        } else {
             Map<String, Object> mapObj = new HashMap<String, Object>();
             mapObj.putAll(attributes);
 

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -20,7 +20,7 @@ import java.math.BigDecimal;
 import java.util.*;
 
 import static com.mparticle.ext.iterable.IterableExtension.SETTING_API_KEY;
-import static com.mparticle.ext.iterable.IterableExtension.SETTING_PARSE_USER_ATTRIBUTES;
+import static com.mparticle.ext.iterable.IterableExtension.SETTING_COERCE_STRINGS_TO_SCALARS;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.times;
 
@@ -151,13 +151,13 @@ public class IterableExtensionTest {
         userAttributes.put("test_float", "1.5");
         request.setUserAttributes(userAttributes);
         
-        settings.put(SETTING_PARSE_USER_ATTRIBUTES, "True");
+        settings.put(SETTING_COERCE_STRINGS_TO_SCALARS, "True");
         extension.updateUser(request);
         
-        settings.put(SETTING_PARSE_USER_ATTRIBUTES, "False");
+        settings.put(SETTING_COERCE_STRINGS_TO_SCALARS, "False");
         extension.updateUser(request);
 
-        settings.remove(SETTING_PARSE_USER_ATTRIBUTES);
+        settings.remove(SETTING_COERCE_STRINGS_TO_SCALARS);
         extension.updateUser(request);
 
         ArgumentCaptor<UserUpdateRequest> argument = ArgumentCaptor.forClass(UserUpdateRequest.class);
@@ -166,17 +166,17 @@ public class IterableExtensionTest {
 
         List<UserUpdateRequest> actualRequests = argument.getAllValues();
 
-        // SETTING_PARSE_USER_ATTRIBUTES == True
+        // SETTING_COERCE_STRINGS_TO_SCALARS == True
         assertEquals(true, actualRequests.get(0).dataFields.get("test_bool"));
         assertEquals(123, actualRequests.get(0).dataFields.get("test_int"));
         assertEquals(1.5, actualRequests.get(0).dataFields.get("test_float"));
 
-        // SETTING_PARSE_USER_ATTRIBUTES == False
+        // SETTING_COERCE_STRINGS_TO_SCALARS == False
         assertEquals("True", actualRequests.get(1).dataFields.get("test_bool"));
         assertEquals("123", actualRequests.get(1).dataFields.get("test_int"));
         assertEquals("1.5", actualRequests.get(1).dataFields.get("test_float"));
 
-        // SETTING_PARSE_USER_ATTRIBUTES not set
+        // SETTING_COERCE_STRINGS_TO_SCALARS not set
         assertEquals("True", actualRequests.get(2).dataFields.get("test_bool"));
         assertEquals("123", actualRequests.get(2).dataFields.get("test_int"));
         assertEquals("1.5", actualRequests.get(2).dataFields.get("test_float"));
@@ -532,15 +532,22 @@ public class IterableExtensionTest {
         product.setCategory("some category");
         Map<String, String> attributes = new HashMap<>();
         attributes.put("a key", "a value");
+        attributes.put("an int key", "123");
         product.setAttributes(attributes);
         product.setQuantity(new BigDecimal(1.4));
-        CommerceItem item = new IterableExtension().convertToCommerceItem(product);
+        CommerceItem item = new IterableExtension().convertToCommerceItem(product, true);
         assertEquals("some id", item.id);
         assertEquals("some id", item.sku);
         assertEquals("some name", item.name);
         assertEquals("some category", item.categories.get(0));
         assertEquals("a value", item.dataFields.get("a key"));
+        assertEquals(123, item.dataFields.get("an int key"));
         assertEquals((Integer) new BigDecimal(1.4).intValue(), item.quantity);
+
+        item = new IterableExtension().convertToCommerceItem(product, false);
+        assertEquals("123", item.dataFields.get("an int key"));
+
+
     }
 
     @org.junit.Test

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/ApiUser.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/ApiUser.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class ApiUser {
     public String email;
-    public Map<String, String> dataFields;
+    public Map<String, Object> dataFields;
     public String userId;
 
 }

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/CommerceItem.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/CommerceItem.java
@@ -14,6 +14,6 @@ public class CommerceItem {
     //iterable will error if this is not present
     public Integer quantity = 1;
     public String imageUrl;
-    public Map<String, String> dataFields;
+    public Map<String, Object> dataFields;
 
 }

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/Device.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/Device.java
@@ -7,7 +7,7 @@ public class Device {
     public String token;
     public String platform;
     public String applicationName;
-    public Map<String, String> dataFields;
+    public Map<String, Object> dataFields;
     public static String PLATFORM_APNS = "APNS";
     public static String PLATFORM_APNS_SANDBOX = "APNS_SANDBOX";
     public static String PLATFORM_GCM = "GCM";

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableRequest.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableRequest.java
@@ -16,7 +16,7 @@ public abstract class IterableRequest {
     /**
      *  Additional data associated with event (i.e. item id, item amount),
      */
-    public Map<String, String> dataFields;
+    public Map<String, Object> dataFields;
     /**
      * userId that was passed into the updateUser call
      */

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/TrackPurchaseRequest.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/TrackPurchaseRequest.java
@@ -12,5 +12,5 @@ public class TrackPurchaseRequest {
     public Integer templateId;
     public BigDecimal total;
     public Integer createdAt;
-    public Map<String, String> dataFields;
+    public Map<String, Object> dataFields;
 }

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/UserUpdateRequest.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/UserUpdateRequest.java
@@ -4,6 +4,6 @@ import java.util.Map;
 
 public class UserUpdateRequest {
     public String email;
-    public Map<String, String> dataFields;
+    public Map<String, Object> dataFields;
     public String userId;
 }

--- a/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
+++ b/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
@@ -81,7 +81,7 @@ public class IterableServiceTest {
         pushOpenRequest.userId = TEST_USER_ID;
         pushOpenRequest.campaignId = 17703; //this correlates to the "Test Campaign" set up in Iterable
 	pushOpenRequest.messageId= "eac02374a90d46a2901cea2f52edbd70"; // This needs to be a valid messageId in the project you're testing.
-        Map<String, String> attributes = new HashMap<String, String>();
+        Map<String, Object> attributes = new HashMap<String, Object>();
         attributes.put("test push open attribute key", "test push open attribute value");
         pushOpenRequest.dataFields = attributes;
         Response<IterableApiResponse> response = iterableService.trackPushOpen(ITERABLE_API_KEY, pushOpenRequest).execute();

--- a/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
+++ b/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
@@ -96,6 +96,9 @@ public class IterableServiceTest {
         userUpdateRequest.email = TEST_EMAIL;
         Map<String, Object> attributes = new HashMap<String, Object>();
         attributes.put("test string key", "test attribute string value");
+        attributes.put("test boolean key", true);
+        attributes.put("test int key", 1234);
+        attributes.put("test double key", 1234.56D);
 
         userUpdateRequest.dataFields = attributes;
         Response<IterableApiResponse> response = iterableService.userUpdate(ITERABLE_API_KEY, userUpdateRequest).execute();

--- a/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
+++ b/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
@@ -95,7 +95,7 @@ public class IterableServiceTest {
         userUpdateRequest.userId = TEST_USER_ID;
         userUpdateRequest.email = TEST_EMAIL;
         Map<String, Object> attributes = new HashMap<String, Object>();
-        attributes.put("test attribute key", "test attribute value");
+        attributes.put("test string key", "test attribute string value");
 
         userUpdateRequest.dataFields = attributes;
         Response<IterableApiResponse> response = iterableService.userUpdate(ITERABLE_API_KEY, userUpdateRequest).execute();

--- a/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
+++ b/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
@@ -94,7 +94,7 @@ public class IterableServiceTest {
         UserUpdateRequest userUpdateRequest = new UserUpdateRequest();
         userUpdateRequest.userId = TEST_USER_ID;
         userUpdateRequest.email = TEST_EMAIL;
-        Map<String, String> attributes = new HashMap<String, String>();
+        Map<String, Object> attributes = new HashMap<String, Object>();
         attributes.put("test attribute key", "test attribute value");
 
         userUpdateRequest.dataFields = attributes;
@@ -127,12 +127,12 @@ public class IterableServiceTest {
         String email1 = userId1 + "@mparticle.com";
         String email2 = userId2 + "@mparticle.com";
         ApiUser user1 = new ApiUser();
-        Map<String, String> attributes1 = new HashMap<String, String>();
+        Map<String, Object> attributes1 = new HashMap<String, Object>();
         attributes1.put("test subscribe key", "test subscribe value 1");
         user1.dataFields = attributes1;
         user1.email = email1;
         user1.userId = userId1;
-        Map<String, String> attributes2 = new HashMap<String, String>();
+        Map<String, Object> attributes2 = new HashMap<String, Object>();
         attributes2.put("test subscribe key", "test subscribe value 2");
         ApiUser user2 = new ApiUser();
         user2.dataFields = attributes2;


### PR DESCRIPTION
This adds the ability to parse user attributes into types based on the new `parseUserAttributes` setting. By default, it will maintain the existing behavior and forward user attributes as strings.