### PR TITLE
[PIR-35] Add MPID to the Audience integration

### DIFF
--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -796,6 +796,9 @@ public class IterableExtension extends MessageProcessor {
         }
         if (shouldUseMPID(account)) {
             request.userId = mpid;
+            if (request.email == null && mpid != null) {
+                request.email = mpid + "@placeholder.email";
+            }
         }
     }
 

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -812,7 +812,7 @@ public class IterableExtension extends MessageProcessor {
         }
         if (shouldUseMPID(account)) {
             request.userId = mpid;
-            if (request.email == null && mpid != null) {
+            if (request.email == null) {
                 request.email = mpid + PLACEHOLDER_EMAIL_DOMAIN;
             }
         }

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -406,7 +406,7 @@ public class IterableExtension extends MessageProcessor {
         if (isEmpty(id)) {
             throw new IOException("Unable to send user to Iterable - no email and unable to construct placeholder.");
         }
-        return id + "@placeholder.email";
+        return id + PLACEHOLDER_EMAIL_DOMAIN;
     }
 
     @Override

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -28,6 +28,7 @@ public class IterableExtension extends MessageProcessor {
     public static final String SETTING_USER_ID_FIELD = "userIdField";
     public static final String USER_ID_FIELD_CUSTOMER_ID = "customerId";
     public static final String USER_ID_FIELD_MPID = "mpid";
+    public static final String PLACEHOLDER_EMAIL_DOMAIN = "@placeholder.email";
     IterableService iterableService;
 
     @Override
@@ -812,7 +813,7 @@ public class IterableExtension extends MessageProcessor {
         if (shouldUseMPID(account)) {
             request.userId = mpid;
             if (request.email == null && mpid != null) {
-                request.email = mpid + "@placeholder.email";
+                request.email = mpid + PLACEHOLDER_EMAIL_DOMAIN;
             }
         }
     }

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -696,6 +696,21 @@ public class IterableExtension extends MessageProcessor {
         }
     }
 
+    /**
+     * Map an AudienceMembershipChangeRequest to Iterable's list subscribe and unsubscribe requests.
+     *
+     * Requests are made to the /api/lists/subscribe and /api/lists/unsubscribe endpoint. Each request
+     * will contain multiple users if there are multiple users being added or removed from the same
+     * list. No dataFields are sent with the users.
+     *
+     * https://api.iterable.com/api/docs#lists_subscribe
+     * https://api.iterable.com/api/docs#lists_unsubscribe
+     *
+     * @param request the request
+     * @return a response that indicates the request was processed successfully
+     * @throws IOException
+     */
+    @Override
     public AudienceMembershipChangeResponse processAudienceMembershipChangeRequest(AudienceMembershipChangeRequest request) throws IOException {
         HashMap<Integer, List<ApiUser>> additions = new HashMap<>();
         HashMap<Integer, List<ApiUser>> removals = new HashMap<>();

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -642,7 +642,7 @@ public class IterableExtensionTest {
                 (a, b) -> a.listId > b.listId ? 1 : a.listId == b.listId ? 0 : -1
         );
         assertEquals(1, subscribeRequests.get(0).listId.intValue());
-        assertEquals(1, subscribeRequests.get(1).listId.intValue());
+        assertEquals(2, subscribeRequests.get(1).listId.intValue());
         int expectedUserSubscribeCount = 0;
         for (ApiUser user : subscribeRequests.get(0).subscribers) {
             switch (user.email) {

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -641,8 +641,8 @@ public class IterableExtensionTest {
                 subscribeRequests,
                 (a, b) -> a.listId > b.listId ? 1 : a.listId == b.listId ? 0 : -1
         );
-        assertEquals(new Integer(1), subscribeRequests.get(0).listId);
-        assertEquals(new Integer(2), subscribeRequests.get(1).listId);
+        assertEquals(1, subscribeRequests.get(0).listId.intValue());
+        assertEquals(1, subscribeRequests.get(1).listId.intValue());
         int expectedUserSubscribeCount = 0;
         for (ApiUser user : subscribeRequests.get(0).subscribers) {
             switch (user.email) {
@@ -668,7 +668,7 @@ public class IterableExtensionTest {
         ArgumentCaptor<UnsubscribeRequest> unsubArg = ArgumentCaptor.forClass(UnsubscribeRequest.class);
         List<UnsubscribeRequest> unsubscribeRequests = unsubArg.getAllValues();
         Mockito.verify(iterableServiceMock, Mockito.times(1)).listUnsubscribe(Mockito.any(), unsubArg.capture());
-        assertEquals(new Integer(3), unsubscribeRequests.get(0).listId);
+        assertEquals(3, unsubscribeRequests.get(0).listId.intValue());
         int expectedUserUnsubscribeCount = 0;
         for (ApiUser user : unsubscribeRequests.get(0).subscribers) {
             switch (user.email) {
@@ -684,7 +684,6 @@ public class IterableExtensionTest {
                     break;
                 case "email_and_id@iterable.com":
                     // testUserProfileWIthEmailAndCustomerId
-                    // and userId: "<MPID>"
                     assertEquals("m3", user.userId);
                     expectedUserUnsubscribeCount++;
                     break;

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -9,6 +9,7 @@ import com.mparticle.sdk.model.registration.Account;
 import com.mparticle.sdk.model.registration.ModuleRegistrationResponse;
 import com.mparticle.sdk.model.registration.Setting;
 import com.mparticle.sdk.model.registration.UserIdentityPermission;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -19,15 +20,73 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.*;
 
-import static com.mparticle.ext.iterable.IterableExtension.SETTING_API_KEY;
-import static com.mparticle.ext.iterable.IterableExtension.SETTING_COERCE_STRINGS_TO_SCALARS;
-import static com.mparticle.ext.iterable.IterableExtension.SETTING_USER_ID_FIELD;
+import static com.mparticle.ext.iterable.IterableExtension.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 public class IterableExtensionTest {
     private static final String TEST_API_KEY = "foo api key";
+    private IterableExtension testIterableExtension;
+    private IterableService iterableServiceMock;
+    private Call callMock;
+    private Audience testAudienceAddition1;
+    private Audience testAudienceAddition2;
+    private Audience testAudienceDeletion3;
+    private List<Audience> testAudienceList;
+    private UserProfile testUserProfile;
+    private UserProfile testUserProfileWithEmail;
+    private UserProfile testUserProfileWithEmailAndCustomerId;
+    private Account testAccount;
+    private IterableApiResponse testIterableApiSuccess;
+    private Response testSuccessResponse;
+
+    @Before
+    public void setup() {
+        testIterableExtension = new IterableExtension();
+        iterableServiceMock = Mockito.mock(IterableService.class);
+        callMock = Mockito.mock(Call.class);
+
+        testAudienceAddition1 = new Audience();
+        Map<String, String> audienceSubscriptionSettings = new HashMap<>();
+        audienceSubscriptionSettings.put(IterableExtension.SETTING_LIST_ID, "1");
+        testAudienceAddition1.setAudienceSubscriptionSettings(audienceSubscriptionSettings);
+        testAudienceAddition1.setAudienceAction(Audience.AudienceAction.ADD);
+        testAudienceAddition2 = new Audience();
+        Map<String, String> audienceSubscriptionSettings2 = new HashMap<>();
+        audienceSubscriptionSettings2.put(IterableExtension.SETTING_LIST_ID, "2");
+        testAudienceAddition2.setAudienceSubscriptionSettings(audienceSubscriptionSettings2);
+        testAudienceAddition2.setAudienceAction(Audience.AudienceAction.ADD);
+        testAudienceDeletion3 = new Audience();
+        Map<String, String> audienceSubscriptionSettings3 = new HashMap<>();
+        audienceSubscriptionSettings3.put(IterableExtension.SETTING_LIST_ID, "3");
+        testAudienceDeletion3.setAudienceSubscriptionSettings(audienceSubscriptionSettings3);
+        testAudienceDeletion3.setAudienceAction(Audience.AudienceAction.DELETE);
+        testAudienceList = new LinkedList<>();
+        testAudienceList.add(testAudienceAddition2);
+        testAudienceList.add(testAudienceAddition1);
+        testAudienceList.add(testAudienceDeletion3);
+
+        testUserProfile = new UserProfile();
+        testUserProfileWithEmail = new UserProfile();
+        List<UserIdentity> userIdentities1 = new LinkedList<>();
+        userIdentities1.add(new UserIdentity(UserIdentity.Type.EMAIL, Identity.Encoding.RAW, "email_only@iterable.com"));
+        testUserProfileWithEmail.setUserIdentities(userIdentities1);
+        testUserProfileWithEmailAndCustomerId = new UserProfile();
+        List<UserIdentity> userIdentities2 = new LinkedList<>();
+        userIdentities2.add(new UserIdentity(UserIdentity.Type.EMAIL, Identity.Encoding.RAW, "email_and_id@iterable.com"));
+        userIdentities2.add(new UserIdentity(UserIdentity.Type.CUSTOMER, Identity.Encoding.RAW, "c1"));
+        testUserProfileWithEmailAndCustomerId.setUserIdentities(userIdentities2);
+
+        testAccount = new Account();
+        Map<String, String> accountSettings = new HashMap<>();
+        accountSettings.put(SETTING_API_KEY, "some api key");
+        testAccount.setAccountSettings(accountSettings);
+
+        testIterableApiSuccess = new IterableApiResponse();
+        testIterableApiSuccess.code = IterableApiResponse.SUCCESS_MESSAGE;
+        testSuccessResponse = Response.success(testIterableApiSuccess);
+    }
 
     @org.junit.Test
     public void testProcessEventProcessingRequest() throws Exception {
@@ -546,6 +605,93 @@ public class IterableExtensionTest {
             }
         }
         assertEquals(3, i);
+    }
+
+    @Test
+    public void testProcessAudienceMembershipChangeWithMPID() throws IOException {
+        testIterableExtension.iterableService = iterableServiceMock;
+        Mockito.when(iterableServiceMock.listSubscribe(Mockito.any(), Mockito.any()))
+                .thenReturn(callMock);
+        Mockito.when(iterableServiceMock.listUnsubscribe(Mockito.any(), Mockito.any()))
+                .thenReturn(callMock);
+        Mockito.when(callMock.execute()).thenReturn(testSuccessResponse);
+
+        List userProfileList = new LinkedList<UserProfile>();
+        testUserProfile.setMpId("m1");
+        testUserProfile.setAudiences(testAudienceList);
+        testUserProfileWithEmail.setMpId("m2");
+        testUserProfileWithEmail.setAudiences(testAudienceList);
+        testUserProfileWithEmailAndCustomerId.setMpId("m3");
+        testUserProfileWithEmailAndCustomerId.setAudiences(testAudienceList);
+        userProfileList.add(testUserProfile);
+        userProfileList.add(testUserProfileWithEmail);
+        userProfileList.add(testUserProfileWithEmailAndCustomerId);
+
+        AudienceMembershipChangeRequest request = new AudienceMembershipChangeRequest();
+        testAccount.getAccountSettings().put(SETTING_USER_ID_FIELD, USER_ID_FIELD_MPID);
+        request.setAccount(testAccount);
+        request.setUserProfiles(userProfileList);
+
+        testIterableExtension.processAudienceMembershipChangeRequest(request);
+
+        ArgumentCaptor<SubscribeRequest> subscribeArgs = ArgumentCaptor.forClass(SubscribeRequest.class);
+        List<SubscribeRequest> subscribeRequests = subscribeArgs.getAllValues();
+        Mockito.verify(iterableServiceMock, Mockito.times(2)).listSubscribe(Mockito.any(), subscribeArgs.capture());
+        Collections.sort(
+                subscribeRequests,
+                (a, b) -> a.listId > b.listId ? 1 : a.listId == b.listId ? 0 : -1
+        );
+        assertEquals(new Integer(1), subscribeRequests.get(0).listId);
+        assertEquals(new Integer(2), subscribeRequests.get(1).listId);
+        int expectedUserSubscribeCount = 0;
+        for (ApiUser user : subscribeRequests.get(0).subscribers) {
+            switch (user.email) {
+                case "m1@placeholder.email":
+                    // testUserProfile should have email: "<MPID>@placeholder.email" and userId: "<MPID>"
+                    assertEquals("m1", user.userId);
+                    expectedUserSubscribeCount++;
+                    break;
+                case "email_only@iterable.com":
+                    // testUserProfileWithEmail should have email: "email@itearble.com" and userId: "<MPID>"
+                    assertEquals("m2", user.userId);
+                    expectedUserSubscribeCount++;
+                    break;
+                case "email_and_id@iterable.com":
+                    // testUserProfileWIthEmailAndCustomerId should have email: "email_and_id@iterable.com"
+                    // and userId: "<MPID>"
+                    assertEquals("m3", user.userId);
+                    expectedUserSubscribeCount++;
+                    break;
+            }
+        }
+        assertEquals(3, expectedUserSubscribeCount);
+
+        ArgumentCaptor<UnsubscribeRequest> unsubArg = ArgumentCaptor.forClass(UnsubscribeRequest.class);
+        List<UnsubscribeRequest> unsubscribeRequests = unsubArg.getAllValues();
+        Mockito.verify(iterableServiceMock, Mockito.times(1)).listUnsubscribe(Mockito.any(), unsubArg.capture());
+        assertEquals(new Integer(3), unsubscribeRequests.get(0).listId);
+        int expectedUserUnsubscribeCount = 0;
+        for (ApiUser user : unsubscribeRequests.get(0).subscribers) {
+            switch (user.email) {
+                case "m1@placeholder.email":
+                    // testUserProfile should have email: "<MPID>@placeholder.email" and userId: "<MPID>"
+                    assertEquals("m1", user.userId);
+                    expectedUserUnsubscribeCount++;
+                    break;
+                case "email_only@iterable.com":
+                    // testUserProfileWithEmail should have email: "email@itearble.com" and userId: "<MPID>"
+                    assertEquals("m2", user.userId);
+                    expectedUserUnsubscribeCount++;
+                    break;
+                case "email_and_id@iterable.com":
+                    // testUserProfileWIthEmailAndCustomerId should have email: "email_and_id@iterable.com"
+                    // and userId: "<MPID>"
+                    assertEquals("m3", user.userId);
+                    expectedUserUnsubscribeCount++;
+                    break;
+            }
+        }
+        assertEquals(3, expectedUserUnsubscribeCount);
     }
 
     @org.junit.Test

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -647,18 +647,17 @@ public class IterableExtensionTest {
         for (ApiUser user : subscribeRequests.get(0).subscribers) {
             switch (user.email) {
                 case "m1@placeholder.email":
-                    // testUserProfile should have email: "<MPID>@placeholder.email" and userId: "<MPID>"
+                    // testUserProfile
                     assertEquals("m1", user.userId);
                     expectedUserSubscribeCount++;
                     break;
                 case "email_only@iterable.com":
-                    // testUserProfileWithEmail should have email: "email@itearble.com" and userId: "<MPID>"
+                    // testUserProfileWithEmail
                     assertEquals("m2", user.userId);
                     expectedUserSubscribeCount++;
                     break;
                 case "email_and_id@iterable.com":
-                    // testUserProfileWIthEmailAndCustomerId should have email: "email_and_id@iterable.com"
-                    // and userId: "<MPID>"
+                    // testUserProfileWIthEmailAndCustomerId
                     assertEquals("m3", user.userId);
                     expectedUserSubscribeCount++;
                     break;
@@ -674,17 +673,17 @@ public class IterableExtensionTest {
         for (ApiUser user : unsubscribeRequests.get(0).subscribers) {
             switch (user.email) {
                 case "m1@placeholder.email":
-                    // testUserProfile should have email: "<MPID>@placeholder.email" and userId: "<MPID>"
+                    // testUserProfile
                     assertEquals("m1", user.userId);
                     expectedUserUnsubscribeCount++;
                     break;
                 case "email_only@iterable.com":
-                    // testUserProfileWithEmail should have email: "email@itearble.com" and userId: "<MPID>"
+                    // testUserProfileWithEmail
                     assertEquals("m2", user.userId);
                     expectedUserUnsubscribeCount++;
                     break;
                 case "email_and_id@iterable.com":
-                    // testUserProfileWIthEmailAndCustomerId should have email: "email_and_id@iterable.com"
+                    // testUserProfileWIthEmailAndCustomerId
                     // and userId: "<MPID>"
                     assertEquals("m3", user.userId);
                     expectedUserUnsubscribeCount++;


### PR DESCRIPTION
## Status

**READY**

## Jira Ticket(s)

* [PIR-35](https://iterable.atlassian.net/browse/PIR-35)

## Description

The Audience integration only forwards users with an email address to Iterable. This PR updates the Audience integration so users without an email address receive a placeholder email address if the Account is using MPID as the userId.