### PR TITLE
[PIR-32] Convert mParticle reserved "$Mobile" to Iterable reserved "phoneNumber"

### DIFF
--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -267,7 +267,7 @@ public class IterableExtension extends MessageProcessor {
         convertedAttrs.putAll(attributes);
         if (convertedAttrs.containsKey(MPARTICLE_RESERVED_PHONE_ATTR)) {
             String phoneNumber = convertedAttrs.get(MPARTICLE_RESERVED_PHONE_ATTR);
-            String formattedNumber = phoneNumber.replaceAll("[\\D]", "");
+            String formattedNumber = phoneNumber.replaceAll("[^0-9+]", "");
             convertedAttrs.put(ITERABLE_RESERVED_PHONE_ATTR, formattedNumber);
             convertedAttrs.remove(MPARTICLE_RESERVED_PHONE_ATTR);
         }

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -29,8 +29,8 @@ public class IterableExtension extends MessageProcessor {
     public static final String USER_ID_FIELD_CUSTOMER_ID = "customerId";
     public static final String USER_ID_FIELD_MPID = "mpid";
     public static final String PLACEHOLDER_EMAIL_DOMAIN = "@placeholder.email";
-    public static final String MPARTICLE_PHONE_FIELD = "$Mobile";
-    public static final String ITERABLE_PHONE_FIELD = "phoneNumber";
+    public static final String MPARTICLE_RESERVED_PHONE_ATTR = "$Mobile";
+    public static final String ITERABLE_RESERVED_PHONE_ATTR = "phoneNumber";
     IterableService iterableService;
 
     @Override
@@ -265,11 +265,11 @@ public class IterableExtension extends MessageProcessor {
     private static Map<String, String> convertReservedAttributes(Map<String, String> attributes) {
         Map<String, String> convertedAttrs = new HashMap<String, String>();
         convertedAttrs.putAll(attributes);
-        if (convertedAttrs.containsKey(MPARTICLE_PHONE_FIELD)) {
-            String phoneNumber = convertedAttrs.get(MPARTICLE_PHONE_FIELD);
+        if (convertedAttrs.containsKey(MPARTICLE_RESERVED_PHONE_ATTR)) {
+            String phoneNumber = convertedAttrs.get(MPARTICLE_RESERVED_PHONE_ATTR);
             String formattedNumber = phoneNumber.replaceAll("[\\D]", "");
-            convertedAttrs.put(ITERABLE_PHONE_FIELD, formattedNumber);
-            convertedAttrs.remove(MPARTICLE_PHONE_FIELD);
+            convertedAttrs.put(ITERABLE_RESERVED_PHONE_ATTR, formattedNumber);
+            convertedAttrs.remove(MPARTICLE_RESERVED_PHONE_ATTR);
         }
         return convertedAttrs;
     }

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -29,6 +29,8 @@ public class IterableExtension extends MessageProcessor {
     public static final String USER_ID_FIELD_CUSTOMER_ID = "customerId";
     public static final String USER_ID_FIELD_MPID = "mpid";
     public static final String PLACEHOLDER_EMAIL_DOMAIN = "@placeholder.email";
+    public static final String MPARTICLE_PHONE_FIELD = "$Mobile";
+    public static final String ITERABLE_PHONE_FIELD = "phoneNumber";
     IterableService iterableService;
 
     @Override
@@ -248,15 +250,28 @@ public class IterableExtension extends MessageProcessor {
         if (attributes == null) {
             return null;
         }
+        Map<String, String> attributesWithReserved = convertReservedAttributes(attributes);
         
         if (coerceStringsToScalars) {
-            return attemptTypeConversion(attributes);
+            return attemptTypeConversion(attributesWithReserved);
         } else {
             Map<String, Object> mapObj = new HashMap<String, Object>();
-            mapObj.putAll(attributes);
+            mapObj.putAll(attributesWithReserved);
 
             return mapObj;
         }
+    }
+
+    private static Map<String, String> convertReservedAttributes(Map<String, String> attributes) {
+        Map<String, String> convertedAttrs = new HashMap<String, String>();
+        convertedAttrs.putAll(attributes);
+        if (convertedAttrs.containsKey(MPARTICLE_PHONE_FIELD)) {
+            String phoneNumber = convertedAttrs.get(MPARTICLE_PHONE_FIELD);
+            String formattedNumber = phoneNumber.replaceAll("[\\D]", "");
+            convertedAttrs.put(ITERABLE_PHONE_FIELD, formattedNumber);
+            convertedAttrs.remove(MPARTICLE_PHONE_FIELD);
+        }
+        return convertedAttrs;
     }
 
     private static boolean shouldCoerceStrings(EventProcessingRequest request) {

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -188,7 +188,7 @@ public class IterableExtensionTest {
         EventProcessingRequest request = createEventProcessingRequest();
         Map<String, String> userAttributes = new HashMap<String, String>();
         userAttributes.put("some attribute key", "some attribute value");
-        userAttributes.put(MPARTICLE_PHONE_FIELD, "+1555-876-5309");
+        userAttributes.put(MPARTICLE_RESERVED_PHONE_ATTR, "+1555-876-5309");
         request.setUserAttributes(userAttributes);
         request.setUserIdentities(userIdentitiesWithEmail);
 
@@ -202,7 +202,7 @@ public class IterableExtensionTest {
         assertEquals("Non-reserved attributes should be unchanged",
                 "some attribute value", args.getValue().dataFields.get("some attribute key"));
         assertNull("mParticle reserved attribute shouldn't be present",
-                args.getValue().dataFields.get(MPARTICLE_PHONE_FIELD));
+                args.getValue().dataFields.get(MPARTICLE_RESERVED_PHONE_ATTR));
     }
 
     @org.junit.Test

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -197,7 +197,7 @@ public class IterableExtensionTest {
         Mockito.verify(testIterableExtension.iterableService, times(1))
                 .userUpdate(any(), args.capture());
 
-        assertEquals("Reserved phone number attribute should be converted with special characters removed",
+        assertEquals("Reserved phone number attribute should be converted with non-digit characters removed",
                 "15558765309", args.getValue().dataFields.get("phoneNumber"));
         assertEquals("Non-reserved attributes should be unchanged",
                 "some attribute value", args.getValue().dataFields.get("some attribute key"));

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -188,7 +188,7 @@ public class IterableExtensionTest {
         EventProcessingRequest request = createEventProcessingRequest();
         Map<String, String> userAttributes = new HashMap<String, String>();
         userAttributes.put("some attribute key", "some attribute value");
-        userAttributes.put(MPARTICLE_RESERVED_PHONE_ATTR, "+1555-876-5309");
+        userAttributes.put(MPARTICLE_RESERVED_PHONE_ATTR, "+1 (555) 876-5309");
         request.setUserAttributes(userAttributes);
         request.setUserIdentities(userIdentitiesWithEmail);
 
@@ -198,7 +198,7 @@ public class IterableExtensionTest {
                 .userUpdate(any(), args.capture());
 
         assertEquals("Reserved phone number attribute should be converted with non-digit characters removed",
-                "15558765309", args.getValue().dataFields.get("phoneNumber"));
+                "+15558765309", args.getValue().dataFields.get("phoneNumber"));
         assertEquals("Non-reserved attributes should be unchanged",
                 "some attribute value", args.getValue().dataFields.get("some attribute key"));
         assertNull("mParticle reserved attribute shouldn't be present",


### PR DESCRIPTION
## Status

**READY**

## Jira Ticket(s)

* [PIR-32](https://iterable.atlassian.net/browse/PIR-32)

## Description

mParticle has a reserved user attribute for storing mobile phone numbers: https://docs.mparticle.com/developers/sdk/web/users/#reserved-attributes. This PR maps that reserved attribute to the corresponding Iterable reserved user attribute.