### PR TITLE
[PIR-38] Improve error handling and logging

### DIFF
--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -779,7 +779,8 @@ public class IterableExtension extends MessageProcessor {
                     throw new IOException("Error sending list subscribe to Iterable: HTTP " + response.code());
                 }
             } catch (Exception e) {
-
+                // TODO: Decide how to handle
+                System.out.println("Error sending list subscribe to Iterable");
             }
         }
 
@@ -798,6 +799,8 @@ public class IterableExtension extends MessageProcessor {
                     throw new IOException("Error sending list unsubscribe to Iterable: HTTP " + response.code());
                 }
             } catch (Exception e) {
+                // TODO: Decide how to handle
+                System.out.println("Error sending list unsubscribe to Iterable");
 
             }
         }

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -83,7 +83,7 @@ public class IterableExtension extends MessageProcessor {
                         }
                         request.createdAt = (int) (event.getTimestamp() / 1000.0);
                         Response<IterableApiResponse> response = iterableService.trackPushOpen(getApiKey(processingRequest), request).execute();
-                        handleIterableResponse(response, event.getId().toString());
+                        handleIterableResponse(response, event.getId());
                     }
                 }
             }
@@ -166,7 +166,7 @@ public class IterableExtension extends MessageProcessor {
         }
 
         Response<IterableApiResponse> response = iterableService.registerToken(getApiKey(event), request).execute();
-        handleIterableResponse(response, event.getId().toString());
+        handleIterableResponse(response, event.getId());
     }
 
     void updateUser(EventProcessingRequest request) throws IOException {
@@ -230,7 +230,7 @@ public class IterableExtension extends MessageProcessor {
             if (!isEmpty(userUpdateRequest.email) || !isEmpty(userUpdateRequest.userId)) {
                 userUpdateRequest.dataFields = convertAttributes(request.getUserAttributes(), shouldCoerceStrings(request));
                 Response<IterableApiResponse> response = iterableService.userUpdate(getApiKey(request), userUpdateRequest).execute();
-                handleIterableResponse(response, request.getId().toString());
+                handleIterableResponse(response, request.getId());
             }
         }
     }
@@ -311,7 +311,7 @@ public class IterableExtension extends MessageProcessor {
             }
 
             Response<IterableApiResponse> response = iterableService.trackPurchase(getApiKey(event), purchaseRequest).execute();
-            handleIterableResponse(response, event.getId().toString());
+            handleIterableResponse(response, event.getId());
         }
     }
 
@@ -565,7 +565,7 @@ public class IterableExtension extends MessageProcessor {
             return false;
         }
         Response<IterableApiResponse> response = iterableService.updateSubscriptions(getApiKey(event), updateRequest).execute();
-        handleIterableResponse(response, event.getId().toString());
+        handleIterableResponse(response, event.getId());
         return true;
 
     }
@@ -634,7 +634,7 @@ public class IterableExtension extends MessageProcessor {
         addUserIdentitiesToRequest(request, event.getRequest());
 
         Response<IterableApiResponse> response = iterableService.track(getApiKey(event), request).execute();
-        handleIterableResponse(response, event.getId().toString());
+        handleIterableResponse(response, event.getId());
     }
 
     /**
@@ -704,7 +704,7 @@ public class IterableExtension extends MessageProcessor {
                 }
                 request.createdAt = (int) (event.getTimestamp() / 1000.0);
                 Response<IterableApiResponse> response = iterableService.trackPushOpen(getApiKey(event), request).execute();
-                handleIterableResponse(response, event.getId().toString());
+                handleIterableResponse(response, event.getId());
             }
         }
     }
@@ -836,11 +836,12 @@ public class IterableExtension extends MessageProcessor {
                 integrationAttributes.getOrDefault("Iterable.sdkVersion", null) != null;
     }
 
-    static void handleIterableResponse(Response<IterableApiResponse> response, String eventId) throws IOException {
+    static void handleIterableResponse(Response<IterableApiResponse> response, UUID eventId) throws IOException {
         Boolean isResponseBodySuccess = response.body() != null && response.body().isSuccess();
         if (!response.isSuccessful() || !isResponseBodySuccess) {
             IterableApiResponse errorBody = IterableErrorHandler.parseError(response);
-            IterableExtensionLogger.logApiError(response, errorBody, eventId);
+            String id = eventId != null ? eventId.toString() : "Unavailable";
+            IterableExtensionLogger.logApiError(response, errorBody, id);
             throw new IOException();
         }
     }

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtensionLogger.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtensionLogger.java
@@ -1,0 +1,27 @@
+package com.mparticle.ext.iterable;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.mparticle.iterable.IterableApiResponse;
+import retrofit2.Response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IterableExtensionLogger {
+
+    private static final Gson gson = new GsonBuilder().create();
+
+    public static void logApiError(Response<IterableApiResponse> response,
+                                   IterableApiResponse errorBody, String eventId) {
+        Map<String, String> logMessage = new HashMap<>();
+        logMessage.put("message", "Error sending request to Iterable");
+        logMessage.put("url", response.raw().request().url().encodedPath());
+        logMessage.put("httpStatus", String.valueOf(response.code()));
+        logMessage.put("iterableApiCode", errorBody.code);
+        logMessage.put("mParticleEventId", eventId);
+
+        String messageJson = gson.toJson(logMessage);
+        System.out.println(messageJson);
+    }
+}

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -14,6 +14,7 @@ import okhttp3.ResponseBody;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import retrofit2.Call;
 import retrofit2.Response;
@@ -100,7 +101,7 @@ public class IterableExtensionTest {
     }
 
     @org.junit.Test
-    public void testProcessEventProcessingRequest() throws Exception {
+    public void testProcessEventProcessingRequest() {
         IterableExtension extension = new IterableExtension();
         EventProcessingRequest request = createEventProcessingRequest();
         List<Event> events = new LinkedList<>();
@@ -120,7 +121,11 @@ public class IterableExtensionTest {
         events.add(customEvent4);
 
         request.setEvents(events);
-        extension.processEventProcessingRequest(request);
+        try {
+            extension.processEventProcessingRequest(request);
+        } catch (IOException e) {
+            // Without an API key, this will throw because the extension isn't mocked.
+        }
         assertNotNull("IterableService should have been created", extension.iterableService);
 
         assertEquals("Events should have been in order",1, request.getEvents().get(0).getTimestamp());
@@ -976,12 +981,12 @@ public class IterableExtensionTest {
 
     @Test
     public void testHandleIterableSuccess() throws IOException{
-        IterableExtension.handleIterableResponse(testSuccessResponse);
+        IterableExtension.handleIterableResponse(testSuccessResponse, "e1");
     }
 
     @Test(expected = IOException.class)
     public void testHandleIterableError() throws IOException {
-        IterableExtension.handleIterableResponse(testErrorResponse);
+        IterableExtension.handleIterableResponse(testErrorResponse, "e1");
     }
 
     private EventProcessingRequest createEventProcessingRequest() {

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -14,12 +14,13 @@ import okhttp3.ResponseBody;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import retrofit2.Call;
 import retrofit2.Response;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.math.BigDecimal;
 import java.util.*;
 
@@ -985,8 +986,22 @@ public class IterableExtensionTest {
     }
 
     @Test(expected = IOException.class)
-    public void testHandleIterableError() throws IOException {
+    public void testHandleIterableErrorThrowsException() throws IOException {
         IterableExtension.handleIterableResponse(testErrorResponse, "e1");
+    }
+
+    @Test
+    public void testHandleIterableErrorLogsError() {
+        String expectedLogMessage = "{\"iterableApiCode\":\"InvalidEmailAddressError\",\"mParticleEventId\":\"e1\",\"httpStatus\":\"400\",\"message\":\"Error sending request to Iterable\",\"url\":\"/\"}\n";
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+
+        try {
+            IterableExtension.handleIterableResponse(testErrorResponse, "e1");
+        } catch (IOException ignored) {
+        }
+        assertEquals(expectedLogMessage, outContent.toString());
+        System.setOut(System.out);
     }
 
     private EventProcessingRequest createEventProcessingRequest() {

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -982,22 +982,25 @@ public class IterableExtensionTest {
 
     @Test
     public void testHandleIterableSuccess() throws IOException{
-        IterableExtension.handleIterableResponse(testSuccessResponse, "e1");
+        IterableExtension.handleIterableResponse(testSuccessResponse,
+                UUID.fromString("d0567916-c2c7-11ea-b3de-0242ac130004"));
     }
 
     @Test(expected = IOException.class)
     public void testHandleIterableErrorThrowsException() throws IOException {
-        IterableExtension.handleIterableResponse(testErrorResponse, "e1");
+        IterableExtension.handleIterableResponse(testErrorResponse,
+                UUID.fromString("d0567916-c2c7-11ea-b3de-0242ac130004"));
     }
 
     @Test
     public void testHandleIterableErrorLogsError() {
-        String expectedLogMessage = "{\"iterableApiCode\":\"InvalidEmailAddressError\",\"mParticleEventId\":\"e1\",\"httpStatus\":\"400\",\"message\":\"Error sending request to Iterable\",\"url\":\"/\"}\n";
+        String expectedLogMessage = "{\"iterableApiCode\":\"InvalidEmailAddressError\",\"mParticleEventId\":\"d0567916-c2c7-11ea-b3de-0242ac130004\",\"httpStatus\":\"400\",\"message\":\"Error sending request to Iterable\",\"url\":\"/\"}\n";
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outContent));
 
         try {
-            IterableExtension.handleIterableResponse(testErrorResponse, "e1");
+            IterableExtension.handleIterableResponse(testErrorResponse,
+                    UUID.fromString("d0567916-c2c7-11ea-b3de-0242ac130004"));
         } catch (IOException ignored) {
         }
         assertEquals(expectedLogMessage, outContent.toString());

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -9,6 +9,8 @@ import com.mparticle.sdk.model.registration.Account;
 import com.mparticle.sdk.model.registration.ModuleRegistrationResponse;
 import com.mparticle.sdk.model.registration.Setting;
 import com.mparticle.sdk.model.registration.UserIdentityPermission;
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -41,6 +43,7 @@ public class IterableExtensionTest {
     private Account testAccount;
     private IterableApiResponse testIterableApiSuccess;
     private Response testSuccessResponse;
+    private Response testErrorResponse;
     private LinkedList<UserIdentity> userIdentitiesWithEmail;
     private LinkedList<UserIdentity> userIdentitiesWithEmailAndCustomerId;
 
@@ -92,6 +95,8 @@ public class IterableExtensionTest {
         testIterableApiSuccess = new IterableApiResponse();
         testIterableApiSuccess.code = IterableApiResponse.SUCCESS_MESSAGE;
         testSuccessResponse = Response.success(testIterableApiSuccess);
+        testErrorResponse = Response.error(400, ResponseBody.create(
+                MediaType.parse("application/json; charset=utf-8"), "{code:\"InvalidEmailAddressError\"}"));
     }
 
     @org.junit.Test
@@ -967,6 +972,16 @@ public class IterableExtensionTest {
             exception = ioe;
         }
         assertNotNull("Iterable extension should have thrown an IOException", exception);
+    }
+
+    @Test
+    public void testHandleIterableSuccess() throws IOException{
+        IterableExtension.handleIterableResponse(testSuccessResponse);
+    }
+
+    @Test(expected = IOException.class)
+    public void testHandleIterableError() throws IOException {
+        IterableExtension.handleIterableResponse(testErrorResponse);
     }
 
     private EventProcessingRequest createEventProcessingRequest() {

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableErrorHandler.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableErrorHandler.java
@@ -2,20 +2,30 @@ package com.mparticle.iterable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import retrofit2.Response;
+
+import java.io.IOException;
 
 public class IterableErrorHandler {
 
     private static final Gson gson = new GsonBuilder().create();
 
-    public static IterableApiResponse parseError(Response<?> response) {
-        IterableApiResponse apiResponse = new IterableApiResponse();
+    public static IterableApiResponse parseError(Response<?> response) throws IOException {
+
+        if (response.errorBody() == null) {
+            throw new IOException("The response did not contain an errorBody");
+        }
 
         try {
-            apiResponse = gson.fromJson(response.errorBody().string(), apiResponse.getClass());
+            String responseJson = response.errorBody().string();
+            IterableApiResponse apiResponse = new IterableApiResponse();
+            apiResponse = gson.fromJson(responseJson, apiResponse.getClass());
             return apiResponse;
-        } catch (Exception e) {
-            return apiResponse;
+        } catch (IOException e) {
+            throw new IOException("Unable to read response body while parsing Iterable API error");
+        } catch (JsonSyntaxException e) {
+            throw new IOException("Unable to deserialize Iterable API error");
         }
     }
 }

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableErrorHandler.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableErrorHandler.java
@@ -1,0 +1,21 @@
+package com.mparticle.iterable;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import retrofit2.Response;
+
+public class IterableErrorHandler {
+
+    private static final Gson gson = new GsonBuilder().create();
+
+    public static IterableApiResponse parseError(Response<?> response) {
+        IterableApiResponse apiResponse = new IterableApiResponse();
+
+        try {
+            apiResponse = gson.fromJson(response.errorBody().string(), apiResponse.getClass());
+            return apiResponse;
+        } catch (Exception e) {
+            return apiResponse;
+        }
+    }
+}

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableService.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableService.java
@@ -2,8 +2,7 @@ package com.mparticle.iterable;
 
 
 
-import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
+import okhttp3.*;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
@@ -12,6 +11,7 @@ import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.Query;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -59,8 +59,20 @@ public interface IterableService {
     @GET("api/lists")
     Call<GetListResponse> lists();
 
+    class HeadersInterceptor implements Interceptor {
+        @Override
+        public Response intercept(Interceptor.Chain chain) throws IOException {
+            Request original = chain.request();
+            Request requestWithHeaders = original.newBuilder()
+                    .header("User-Agent", "mparticle-lambda")
+                    .build();
+            return chain.proceed(requestWithHeaders);
+        }
+    }
+
     static IterableService newInstance() {
         final OkHttpClient client = new OkHttpClient.Builder()
+                .addInterceptor(new HeadersInterceptor())
                 .connectTimeout(SERVICE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
                 .readTimeout(SERVICE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
                 .build();

--- a/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
+++ b/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mockito;
 import retrofit2.Call;
 import retrofit2.Response;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.*;
 
@@ -202,7 +203,7 @@ public class IterableServiceTest {
     }
 
     @Test
-    public void testParseIterableError() {
+    public void testParseIterableError() throws IOException {
         Response testErrorResponse = Response.error(400, ResponseBody.create(
                 MediaType.parse("application/json; charset=utf-8"), ERROR_JSON));
         IterableApiResponse error = IterableErrorHandler.parseError(testErrorResponse);
@@ -211,8 +212,8 @@ public class IterableServiceTest {
         assertEquals("45.29.69.159", error.params.get("ip"));
     }
 
-    @Test
-    public void testParseMalformedIterableError() {
+    @Test(expected = IOException.class)
+    public void testParseMalformedIterableError() throws IOException {
         Response testErrorResponse = Response.error(400, ResponseBody.create(
                 MediaType.parse("application/json; charset=utf-8"), "<p>that's not JSON</p>"));
         IterableApiResponse error = IterableErrorHandler.parseError(testErrorResponse);

--- a/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
+++ b/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
@@ -1,5 +1,7 @@
 package com.mparticle.iterable;
 
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -9,7 +11,7 @@ import retrofit2.Response;
 import java.math.BigDecimal;
 import java.util.*;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * This is an *integration* test, testing:
@@ -23,6 +25,7 @@ public class IterableServiceTest {
     private static final String TEST_EMAIL = "testing@mparticle.com";
     private static final String TEST_USER_ID = "123456";
     private static final String ITERABLE_API_KEY = ""; //put your API key here
+    private static final String ERROR_JSON = "{\"code\":\"BadApiKey\",\"msg\":\"No API key found on request\",\"params\":{\"endpoint\":\"\\/api\\/events\\/track\",\"ip\": \"45.29.69.159\"}}";
 
     private IterableService iterableService;
 
@@ -196,5 +199,23 @@ public class IterableServiceTest {
         assertTrue("Retrofit request not successful:\nMessage: " + response.message() + "\nCode: " + response.code(), response.isSuccessful());
         assertTrue("Iterable response was not successful:\n" + response.body().toString(), response.body().isSuccess());
 
+    }
+
+    @Test
+    public void testParseIterableError() {
+        Response testErrorResponse = Response.error(400, ResponseBody.create(
+                MediaType.parse("application/json; charset=utf-8"), ERROR_JSON));
+        IterableApiResponse error = IterableErrorHandler.parseError(testErrorResponse);
+        assertEquals("BadApiKey", error.code);
+        assertEquals("No API key found on request", error.msg);
+        assertEquals("45.29.69.159", error.params.get("ip"));
+    }
+
+    @Test
+    public void testParseMalformedIterableError() {
+        Response testErrorResponse = Response.error(400, ResponseBody.create(
+                MediaType.parse("application/json; charset=utf-8"), "<p>that's not JSON</p>"));
+        IterableApiResponse error = IterableErrorHandler.parseError(testErrorResponse);
+        assertNotNull(error);
     }
 }


### PR DESCRIPTION
## Status

**READY**

## Jira Ticket(s)

* [PIR-38](https://iterable.atlassian.net/browse/PIR-38)

## Description

- [x] Add an mParticle User-Agent header to requests
- [x] Centralize error handling and logging
- [x] Start logging the mParticle eventId with failed requests
- [x] Start logging the Iterable response `code` with failed requests
