### PR TITLE
[PIR-63] Rename Lambda handler package and class name

### DIFF
--- a/iterable-extension-ingress/src/main/java/com/mparticle/ext/iterable/IterableExtensionIngress.java
+++ b/iterable-extension-ingress/src/main/java/com/mparticle/ext/iterable/IterableExtensionIngress.java
@@ -1,4 +1,4 @@
-package com.mparticle.ext.iterable.ingress;
+package com.mparticle.ext.iterable;
 
 import com.mparticle.sdk.MessageProcessor;
 import com.mparticle.sdk.model.audienceprocessing.AudienceMembershipChangeRequest;

--- a/iterable-extension-ingress/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
+++ b/iterable-extension-ingress/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
@@ -1,4 +1,4 @@
-package com.mparticle.ext.iterable.ingress;
+package com.mparticle.ext.iterable;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
@@ -15,7 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Scanner;
 
-public class IngressLambdaEndpoint implements RequestStreamHandler {
+public class IterableLambdaEndpoint implements RequestStreamHandler {
 
   public static final MessageSerializer serializer = new MessageSerializer();
   public static final IterableExtensionIngress processor = new IterableExtensionIngress();

--- a/iterable-extension-ingress/src/test/java/com/mparticle/ext/iterable/IterableExtensionIngressTest.java
+++ b/iterable-extension-ingress/src/test/java/com/mparticle/ext/iterable/IterableExtensionIngressTest.java
@@ -1,4 +1,4 @@
-package com.mparticle.ext.iterable.ingress;
+package com.mparticle.ext.iterable;
 
 import com.mparticle.sdk.model.MessageSerializer;
 import com.mparticle.sdk.model.audienceprocessing.AudienceMembershipChangeRequest;
@@ -14,8 +14,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 
-import static com.mparticle.ext.iterable.ingress.IterableExtensionIngress.SETTING_API_KEY;
-import static com.mparticle.ext.iterable.ingress.IterableExtensionIngress.SETTING_USER_ID_FIELD;
+import static com.mparticle.ext.iterable.IterableExtensionIngress.SETTING_API_KEY;
+import static com.mparticle.ext.iterable.IterableExtensionIngress.SETTING_USER_ID_FIELD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/iterable-extension-ingress/src/test/java/com/mparticle/ext/iterable/IterableLambdaEndpointTest.java
+++ b/iterable-extension-ingress/src/test/java/com/mparticle/ext/iterable/IterableLambdaEndpointTest.java
@@ -1,4 +1,4 @@
-package com.mparticle.ext.iterable.ingress;
+package com.mparticle.ext.iterable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,14 +13,14 @@ import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 
-public class IngressLambdaEndpointTest {
+public class IterableLambdaEndpointTest {
   private static final ObjectMapper mapper = new ObjectMapper();
   private static final String PATH_TO_FIXTURES = "src/test/resources/";
-  private IngressLambdaEndpoint lambda;
+  private IterableLambdaEndpoint lambda;
 
   @Before
   public void setup() {
-    lambda = new IngressLambdaEndpoint();
+    lambda = new IterableLambdaEndpoint();
     lambda.queueUrl = "";
     lambda.sqsClient = Mockito.mock(SqsClient.class);
   }


### PR DESCRIPTION
## Status

**READY**

## Jira Ticket(s)

* [PIR-63](https://iterable.atlassian.net/browse/PIR-63)

## Description

- Temporarily renaming the package and handler class so it matches the one defined in AWS.
