### PR TITLE
[PIR-76] Ensure IterableService is always initialized for Audience integration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Status
+
+**READY**
+
+## Jira Ticket(s)
+
+* [JIRA-xxx](https://iterable.atlassian.net/browse/JIRA-xxx)
+
+## Description
+
+-
+
+## Testing
+
+- [ ] Unit tested (including negative cases)
+- [ ] Integration tested
+- [ ] Manually tested in with the staging `test` tile

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,4 @@
 
 - [ ] Unit tested (including negative cases)
 - [ ] Integration tested
-- [ ] Manually tested in with the staging `test` tile
+- [ ] Manually tested with the staging `test` tile

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -30,7 +30,7 @@ public class IterableExtension extends MessageProcessor {
     public static final String PLACEHOLDER_EMAIL_DOMAIN = "@placeholder.email";
     public static final String MPARTICLE_RESERVED_PHONE_ATTR = "$Mobile";
     public static final String ITERABLE_RESERVED_PHONE_ATTR = "phoneNumber";
-    IterableService iterableService;
+    IterableService iterableService = IterableService.newInstance();
 
     @Override
     public ModuleRegistrationResponse processRegistrationRequest(ModuleRegistrationRequest request) {
@@ -40,9 +40,6 @@ public class IterableExtension extends MessageProcessor {
 
     @Override
     public EventProcessingResponse processEventProcessingRequest(EventProcessingRequest request) throws IOException {
-        if (iterableService == null) {
-            iterableService = IterableService.newInstance();
-        }
         Collections.sort(
                 request.getEvents(),
                 (a, b) -> a.getTimestamp() > b.getTimestamp() ? 1 : a.getTimestamp() == b.getTimestamp() ? 0 : -1


### PR DESCRIPTION
## Status

**READY**

## Jira Ticket(s)

* [PIR-76](https://iterable.atlassian.net/browse/PIR-76)

## Description

- Before we were lazily initializing the IterableService when the first event batch was received. This PR initializes it when the IterableExtension is created so it's always available.

## Testing

- [x] Unit tested (including negative cases)
- [ ] Integration tested
- [ ] Manually tested in with the staging `test` tile