### PR TITLE
[PIR-103] Prevent NPE in handleIterableListResponse

### DIFF
--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -765,10 +765,10 @@ public class IterableExtension extends MessageProcessor {
             }
             logger.logIterableApiError(preparedCall, response, audienceRequestId, false);
         }
-        boolean hasFailures = response.body().failCount > 0;
-        if (hasFailures) {
+        int failCount = (response.body() == null) ? 0 : response.body().failCount;
+        if (failCount > 0) {
             logger.logMessage(
-                    "List subscribe or unsubscribe request failed count: " + response.body().failCount);
+                    "List subscribe or unsubscribe request failed count: " + failCount);
         }
     }
 


### PR DESCRIPTION
## Status

**READY**

## Jira Ticket(s)

* [PIR-103](https://iterable.atlassian.net/browse/PIR-103)

## Description

- There's a NPE being thrown in handleIterableListResponse. We need to add a null check before accessing `response.body().failCount`

## Testing

- [ ] Unit tested (including negative cases)
- [x] Integration tested
- [x] Manually tested with the staging `test` tile