### PR TITLE
[PIR-105] Extract Blobby code into a dedicated class

### DIFF
--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/BlobbyClient.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/BlobbyClient.java
@@ -1,0 +1,42 @@
+package com.mparticle.ext.iterable;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Simple client for making requests to Blobby
+ */
+public class BlobbyClient {
+    private static final int TIMEOUT_SECONDS = 10;
+    private static final OkHttpClient httpClient = new OkHttpClient.Builder()
+            .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build();
+    private static final String BLOBBY_URL = "https://blobby.internal.prd-itbl.co/mparticle_logs";
+
+    public String log(String msg) {
+        RequestBody body = RequestBody.create(MediaType.parse("text/plain"), msg);
+        Request request = new Request.Builder()
+                .url(BLOBBY_URL)
+                .post(body)
+                .build();
+        okhttp3.Call call = httpClient.newCall(request);
+
+        String blobbyId;
+        try {
+            okhttp3.Response response = call.execute();
+            blobbyId = response.body().string();
+        } catch (Exception e) {
+            StringWriter sw = new StringWriter();
+            e.printStackTrace(new PrintWriter(sw));
+            blobbyId = sw.toString();
+        }
+        return blobbyId;
+    }
+}

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtensionLogger.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtensionLogger.java
@@ -25,12 +25,14 @@ public class IterableExtensionLogger {
   public static final String UNEXPECTED_ERROR = "UnexpectedError";
   private static final Gson gson = new GsonBuilder().create();
   private BlobbyClient blobbyClient;
+  private boolean hasBlobbyEnabled;
   private String awsRequestId;
   private String mparticleBatch;
 
-  public IterableExtensionLogger(String awsRequestId, BlobbyClient bc) {
+  public IterableExtensionLogger(String awsRequestId, BlobbyClient bc, boolean hasBlobbyEnabled) {
     this.awsRequestId = awsRequestId;
     this.blobbyClient = bc;
+    this.hasBlobbyEnabled = hasBlobbyEnabled;
   }
 
   public void logIterableApiError(retrofit2.Call<?> preparedCall,
@@ -137,12 +139,16 @@ public class IterableExtensionLogger {
 
   private String logToBlobby(Map<String, String> message) {
     String blobbyId;
-    try {
-      blobbyId = blobbyClient.log(gson.toJson(message));
-    } catch (Exception e) {
-      StringWriter sw = new StringWriter();
-      e.printStackTrace(new PrintWriter(sw));
-      blobbyId = sw.toString();
+    if (hasBlobbyEnabled) {
+      try {
+        blobbyId = blobbyClient.log(gson.toJson(message));
+      } catch (Exception e) {
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        blobbyId = sw.toString();
+      }
+    } else {
+      blobbyId = "Logging to Blobby is currently disabled";
     }
     return blobbyId;
   }

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtensionLogger.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtensionLogger.java
@@ -2,12 +2,9 @@ package com.mparticle.ext.iterable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import okhttp3.*;
 import okio.Buffer;
-import okio.BufferedSink;
 import retrofit2.Response;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtensionLogger.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtensionLogger.java
@@ -27,13 +27,13 @@ public class IterableExtensionLogger {
   public static final String PROCESSING_ERROR = "ProcessingError";
   public static final String UNEXPECTED_ERROR = "UnexpectedError";
   private static final Gson gson = new GsonBuilder().create();
-  private static final OkHttpClient httpClient = new OkHttpClient();
-  private static final String BLOBBY_URL = "https://blobby.internal.prd-itbl.co/mparticle_logs";
+  private BlobbyClient blobbyClient;
   private String awsRequestId;
   private String mparticleBatch;
 
-  public IterableExtensionLogger(String awsRequestId) {
+  public IterableExtensionLogger(String awsRequestId, BlobbyClient bc) {
     this.awsRequestId = awsRequestId;
+    this.blobbyClient = bc;
   }
 
   public void logIterableApiError(retrofit2.Call<?> preparedCall,
@@ -45,7 +45,7 @@ public class IterableExtensionLogger {
       Buffer buffer = new Buffer();
       preparedCall.request().body().writeTo(buffer);
       requestBody = buffer.readUtf8();
-    } catch (IOException e) {
+    } catch (Exception e) {
       StringWriter sw = new StringWriter();
       e.printStackTrace(new PrintWriter(sw));
       requestBody = sw.toString();
@@ -54,7 +54,7 @@ public class IterableExtensionLogger {
     String responseBody;
     try {
       responseBody = response.errorBody().string();
-    } catch (IOException e ) {
+    } catch (Exception e ) {
       StringWriter sw = new StringWriter();
       e.printStackTrace(new PrintWriter(sw));
       responseBody = sw.toString();
@@ -138,15 +138,10 @@ public class IterableExtensionLogger {
     this.mparticleBatch = mparticleBatch;
   }
 
-  private static String logToBlobby(Map<String, String> message) {
-    RequestBody body = RequestBody.create(MediaType.parse("application/json"), gson.toJson(message));
-    Request request = new Request.Builder().url(BLOBBY_URL).post(body).build();
-    okhttp3.Call call = httpClient.newCall(request);
-
+  private String logToBlobby(Map<String, String> message) {
     String blobbyId;
     try {
-      okhttp3.Response response = call.execute();
-      blobbyId = response.body().string();
+      blobbyId = blobbyClient.log(gson.toJson(message));
     } catch (Exception e) {
       StringWriter sw = new StringWriter();
       e.printStackTrace(new PrintWriter(sw));

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
@@ -10,7 +10,6 @@ import org.apache.commons.io.IOUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.sql.Blob;
 
 public class IterableLambdaEndpoint implements RequestStreamHandler {
 

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
@@ -10,16 +10,18 @@ import org.apache.commons.io.IOUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.sql.Blob;
 
 public class IterableLambdaEndpoint implements RequestStreamHandler {
 
-  static MessageSerializer serializer = new MessageSerializer();
+  static final MessageSerializer serializer = new MessageSerializer();
   static final ObjectMapper mapper = new ObjectMapper();
+  static final BlobbyClient blobbyClient = new BlobbyClient();
 
   @Override
   public void handleRequest(InputStream input, OutputStream output, Context context)
       throws RetriableError {
-    IterableExtensionLogger logger = new IterableExtensionLogger(context.getAwsRequestId());
+    IterableExtensionLogger logger = new IterableExtensionLogger(context.getAwsRequestId(), blobbyClient);
     IterableExtension extension = new IterableExtension(logger);
 
     try {

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
@@ -20,7 +20,7 @@ public class IterableLambdaEndpoint implements RequestStreamHandler {
   @Override
   public void handleRequest(InputStream input, OutputStream output, Context context)
       throws RetriableError {
-    IterableExtensionLogger logger = new IterableExtensionLogger(context.getAwsRequestId(), blobbyClient);
+    IterableExtensionLogger logger = new IterableExtensionLogger(context.getAwsRequestId(), blobbyClient, false);
     IterableExtension extension = new IterableExtension(logger);
 
     try {

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -32,7 +32,6 @@ public class IterableExtensionTest {
     private static final String TEST_API_KEY = "foo api key";
     private IterableExtension testExtension;
     private IterableExtensionLogger testLogger;
-    private BlobbyClient mockBlobbyClient;
     private IterableService iterableServiceMock;
     private Call callMock;
     private Audience testAudienceAddition1;
@@ -51,10 +50,7 @@ public class IterableExtensionTest {
 
     @Before
     public void setup() {
-        mockBlobbyClient = Mockito.mock(BlobbyClient.class);
-        Mockito.when(mockBlobbyClient.log(Mockito.anyString()))
-                .thenReturn("someId");
-        testLogger = new IterableExtensionLogger("foo", mockBlobbyClient);
+        testLogger = new IterableExtensionLogger("foo", new BlobbyClient(), false);
         testExtension = new IterableExtension(testLogger);
         iterableServiceMock = Mockito.mock(IterableService.class);
         callMock = Mockito.mock(Call.class);

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -32,6 +32,7 @@ public class IterableExtensionTest {
     private static final String TEST_API_KEY = "foo api key";
     private IterableExtension testExtension;
     private IterableExtensionLogger testLogger;
+    private BlobbyClient mockBlobbyClient;
     private IterableService iterableServiceMock;
     private Call callMock;
     private Audience testAudienceAddition1;
@@ -50,7 +51,10 @@ public class IterableExtensionTest {
 
     @Before
     public void setup() {
-        testLogger = new IterableExtensionLogger("foo");
+        mockBlobbyClient = Mockito.mock(BlobbyClient.class);
+        Mockito.when(mockBlobbyClient.log(Mockito.anyString()))
+                .thenReturn("someId");
+        testLogger = new IterableExtensionLogger("foo", mockBlobbyClient);
         testExtension = new IterableExtension(testLogger);
         iterableServiceMock = Mockito.mock(IterableService.class);
         callMock = Mockito.mock(Call.class);


### PR DESCRIPTION
## Status

**READY**

## Jira Ticket(s)

* [PIR-105](https://iterable.atlassian.net/browse/PIR-105)

## Description

- Pulls Blobby code out of the IterableExtensionLogger and creates a dedicated BlobbyClient class

## Testing

- [ ] Unit tested (including negative cases)
- [ ] Integration tested
- [x] Manually tested with the staging `test` tile